### PR TITLE
Add Assertions for "Plus Sign Alias" Email Addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ This will prevent any method name conflicts with core, your custom or other trai
 \Astrotomic\PhpunitAssertions\EmailAssertions::assertValidStrict('gummibeer@astrotomic.info');
 \Astrotomic\PhpunitAssertions\EmailAssertions::assertDomain('astrotomic.info', 'gummibeer@astrotomic.info');
 \Astrotomic\PhpunitAssertions\EmailAssertions::assertLocalPart('gummibeer', 'gummibeer@astrotomic.info');
+\Astrotomic\PhpunitAssertions\EmailAssertions::assertPlusMailbox('gummibeer', 'gummibeer+news@astrotomic.info');
+\Astrotomic\PhpunitAssertions\EmailAssertions::assertPlusAlias('news', 'gummibeer+news@astrotomic.info');
 ```
 
 ### Geographic

--- a/src/EmailAssertions.php
+++ b/src/EmailAssertions.php
@@ -42,8 +42,8 @@ trait EmailAssertions
         PHPUnit::assertSame($expected, $mailbox);
 	}
 
-	public static function assertPlusAlias(string $expected, $actual): void
-	{
+    public static function assertPlusAlias(string $expected, $actual): void
+    {
         PHPUnit::assertIsString($actual);
         [$localPart] = explode('@', $actual, 2);
         [$mailbox, $alias] = explode('+', $localPart, 2);

--- a/src/EmailAssertions.php
+++ b/src/EmailAssertions.php
@@ -34,19 +34,19 @@ trait EmailAssertions
         PHPUnit::assertSame($expected, $localPart);
     }
 
-	public static function assertPlusMailbox(string $expected, $actual): void
-	{
-		PHPUnit::assertIsString($actual);
-		[$localPart] = explode('@', $actual, 2);
-		[$mailbox] = explode('+', $localPart, 2);
-		PHPUnit::assertSame($expected, $mailbox);
+    public static function assertPlusMailbox(string $expected, $actual): void
+    {
+        PHPUnit::assertIsString($actual);
+        [$localPart] = explode('@', $actual, 2);
+        [$mailbox] = explode('+', $localPart, 2);
+        PHPUnit::assertSame($expected, $mailbox);
 	}
 
 	public static function assertPlusAlias(string $expected, $actual): void
 	{
-		PHPUnit::assertIsString($actual);
-		[$localPart] = explode('@', $actual, 2);
-		[$mailbox, $alias] = explode('+', $localPart, 2);
-		PHPUnit::assertSame($expected, $alias);
+        PHPUnit::assertIsString($actual);
+        [$localPart] = explode('@', $actual, 2);
+        [$mailbox, $alias] = explode('+', $localPart, 2);
+        PHPUnit::assertSame($expected, $alias);
 	}
 }

--- a/src/EmailAssertions.php
+++ b/src/EmailAssertions.php
@@ -40,7 +40,7 @@ trait EmailAssertions
         [$localPart] = explode('@', $actual, 2);
         [$mailbox] = explode('+', $localPart, 2);
         PHPUnit::assertSame($expected, $mailbox);
-	}
+    }
 
     public static function assertPlusAlias(string $expected, $actual): void
     {
@@ -48,5 +48,5 @@ trait EmailAssertions
         [$localPart] = explode('@', $actual, 2);
         [$mailbox, $alias] = explode('+', $localPart, 2);
         PHPUnit::assertSame($expected, $alias);
-	}
+    }
 }

--- a/src/EmailAssertions.php
+++ b/src/EmailAssertions.php
@@ -33,4 +33,20 @@ trait EmailAssertions
         [$localPart] = explode('@', $actual, 2);
         PHPUnit::assertSame($expected, $localPart);
     }
+
+	public static function assertPlusMailbox(string $expected, $actual): void
+	{
+		PHPUnit::assertIsString($actual);
+		[$localPart] = explode('@', $actual, 2);
+		[$mailbox] = explode('+', $localPart, 2);
+		PHPUnit::assertSame($expected, $mailbox);
+	}
+
+	public static function assertPlusAlias(string $expected, $actual): void
+	{
+		PHPUnit::assertIsString($actual);
+		[$localPart] = explode('@', $actual, 2);
+		[$mailbox, $alias] = explode('+', $localPart, 2);
+		PHPUnit::assertSame($expected, $alias);
+	}
 }

--- a/tests/EmailAssertionsTest.php
+++ b/tests/EmailAssertionsTest.php
@@ -52,7 +52,7 @@ final class EmailAssertionsTest extends TestCase
     {
         $mailbox = self::randomString();
         $alias = self::randomBool();
-        $email = $mailbox . '+' . $alias . '@email.com';
+        $email = $mailbox.'+'.$alias.'@email.com';
 
         EmailAssertions::assertPlusMailbox($mailbox, $email);
     }
@@ -65,7 +65,7 @@ final class EmailAssertionsTest extends TestCase
     {
         $mailbox = self::randomString();
         $alias = self::randomBool();
-        $email = $mailbox . '+' . $alias . '@email.com';
+        $email = $mailbox.'+'.$alias.'@email.com';
 
         EmailAssertions::assertPlusAlias($alias, $email);
     }

--- a/tests/EmailAssertionsTest.php
+++ b/tests/EmailAssertionsTest.php
@@ -43,4 +43,30 @@ final class EmailAssertionsTest extends TestCase
 
         EmailAssertions::assertLocalPart($localPart, $localPart.'@email.com');
     }
+
+	/**
+	 * @test
+	 * @dataProvider hundredTimes
+	 */
+	public static function it_can_validate_plus_mailbox(): void
+	{
+		$mailbox = self::randomString();
+		$alias = self::randomBool();
+		$email = $mailbox . '+' . $alias . '@email.com';
+
+		EmailAssertions::assertPlusMailbox($mailbox, $email);
+	}
+
+	/**
+	 * @test
+	 * @dataProvider hundredTimes
+	 */
+	public static function it_can_validate_plus_alias(): void
+	{
+		$mailbox = self::randomString();
+		$alias = self::randomBool();
+		$email = $mailbox . '+' . $alias . '@email.com';
+
+		EmailAssertions::assertPlusAlias($alias, $email);
+	}
 }

--- a/tests/EmailAssertionsTest.php
+++ b/tests/EmailAssertionsTest.php
@@ -44,29 +44,29 @@ final class EmailAssertionsTest extends TestCase
         EmailAssertions::assertLocalPart($localPart, $localPart.'@email.com');
     }
 
-	/**
-	 * @test
-	 * @dataProvider hundredTimes
-	 */
-	public static function it_can_validate_plus_mailbox(): void
-	{
-		$mailbox = self::randomString();
-		$alias = self::randomBool();
-		$email = $mailbox . '+' . $alias . '@email.com';
+    /**
+     * @test
+     * @dataProvider hundredTimes
+     */
+    public static function it_can_validate_plus_mailbox(): void
+    {
+        $mailbox = self::randomString();
+        $alias = self::randomBool();
+        $email = $mailbox . '+' . $alias . '@email.com';
 
-		EmailAssertions::assertPlusMailbox($mailbox, $email);
-	}
+        EmailAssertions::assertPlusMailbox($mailbox, $email);
+    }
 
-	/**
-	 * @test
-	 * @dataProvider hundredTimes
-	 */
-	public static function it_can_validate_plus_alias(): void
-	{
-		$mailbox = self::randomString();
-		$alias = self::randomBool();
-		$email = $mailbox . '+' . $alias . '@email.com';
+    /**
+     * @test
+     * @dataProvider hundredTimes
+     */
+    public static function it_can_validate_plus_alias(): void
+    {
+        $mailbox = self::randomString();
+        $alias = self::randomBool();
+        $email = $mailbox . '+' . $alias . '@email.com';
 
-		EmailAssertions::assertPlusAlias($alias, $email);
-	}
+        EmailAssertions::assertPlusAlias($alias, $email);
+    }
 }


### PR DESCRIPTION
This pull request adds two assertions to support email addresses like:

myname+spam@example.com 

This type of "plus sign alias" is supported by GMail, Office365, and several other providers.  I couldn't find an official name for this feature, and am open to alternate naming suggestions. 

**New Assertions** 

```
EmailAssertions::assertPlusMailbox('myname, 'myname+spam@example.com')
EmailAssertions::assertPlusAlias('spam', 'myname+spam@example.com');

```