### PR TITLE
Add an OS agnostic path assertion

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,11 +11,15 @@ jobs:
       matrix:
         php: [8.1, 8.0, 7.4]
         dependency-version: [prefer-lowest, prefer-stable]
+        operating-system:
+          - "macos-latest"
+          - "ubuntu-latest"
+          - "windows-latest"
         exclude:
           - php: 8.1
             dependency-version: prefer-lowest
 
-    name: P${{ matrix.php }} - ${{ matrix.dependency-version }}
+    name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.operating-system }}
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ This will prevent any method name conflicts with core, your custom or other trai
 \Astrotomic\PhpunitAssertions\PathAssertions::assertBasename('image.jpg', '/foo/bar/image.jpg');
 \Astrotomic\PhpunitAssertions\PathAssertions::assertFilename('image', '/foo/bar/image.jpg');
 \Astrotomic\PhpunitAssertions\PathAssertions::assertExtension('jpg', '/foo/bar/image.jpg');
+\Astrotomic\PhpunitAssertions\PathAssertions::assertOsAgnosticPath(__DIR__ . '/resources/css/main.css', __DIR__ . '\resources\css\main.css');
 ```
 
 ### UUID

--- a/src/PathAssertions.php
+++ b/src/PathAssertions.php
@@ -31,4 +31,23 @@ final class PathAssertions
         PHPUnit::assertIsString($actual);
         PHPUnit::assertSame($expected, pathinfo($actual, $component));
     }
+
+    private static function agnosticPath(string $path): string
+    {
+        if (DIRECTORY_SEPARATOR === '/') {
+            if (str_contains($path, '\\')) {
+                return str_replace('\\', DIRECTORY_SEPARATOR, $path);
+            }
+            return $path;
+        }
+
+        return str_replace('/', DIRECTORY_SEPARATOR, $path);
+    }
+
+    public static function assertOsAgnosticPath(string $expected, $actual): void
+    {
+        $osNormalizedExpected = PathAssertions::agnosticPath($expected);
+        PHPUnit::assertIsString($actual);
+        PHPUnit::assertSame($osNormalizedExpected, $actual);
+    }
 }

--- a/tests/PathAssertionsTest.php
+++ b/tests/PathAssertionsTest.php
@@ -63,7 +63,7 @@ final class PathAssertionsTest extends TestCase
      *
      * When given the rand: true parameter it will sometimes provide mixed results.
      */
-    private static function get_expected_path(bool $rand = false): string
+    private static function os_agnostic_get_expected_path(bool $rand = false): string
     {
         // Intentionally set the "expected" path to opposite of what should work on the platform.
         if (PHP_OS_FAMILY !== "Windows" || ($rand === true && 1 === self::randomInt(0, 4))) {
@@ -73,19 +73,14 @@ final class PathAssertionsTest extends TestCase
         return dirname(__DIR__) . '/tests/Utils';
     }
 
-    private static function get_actual_path(): string
-    {
-        return realpath(dirname(__DIR__) . '/tests/Utils');
-    }
-
     /**
      * @test
      * @dataProvider hundredTimes
      */
     public static function it_can_validate_os_agnostic_paths(): void
     {
-        $expected = static::get_expected_path(true);
-        PathAssertions::assertOsAgnosticPath($expected, static::get_actual_path());
+        $expected = static::os_agnostic_get_expected_path(true);
+        PathAssertions::assertOsAgnosticPath($expected, realpath(dirname(__DIR__) . '/tests/Utils'));
     }
 
     /**
@@ -94,7 +89,7 @@ final class PathAssertionsTest extends TestCase
      */
     public static function it_can_validate_os_gnostic_paths_fail(): void
     {
-        $expected = static::get_expected_path();
-        static::assertNotEquals($expected, static::get_actual_path());
+        $expected = static::os_agnostic_get_expected_path();
+        static::assertNotEquals($expected, realpath(dirname(__DIR__) . '/tests/Utils'));
     }
 }

--- a/tests/PathAssertionsTest.php
+++ b/tests/PathAssertionsTest.php
@@ -57,4 +57,39 @@ final class PathAssertionsTest extends TestCase
 
         PathAssertions::assertExtension($extension, $directory.'/'.$filename.'.'.$extension);
     }
+
+    private static function get_expected_path(): string
+    {
+        // Intentionally set the "expected" path to opposite of what should work on the platform.
+        if (PHP_OS_FAMILY !== "Windows") {
+            return dirname(__DIR__) . '\tests\Utils';
+        }
+
+        return dirname(__DIR__) . '/tests/Utils';
+    }
+
+    private static function get_actual_path(): string
+    {
+        return realpath(dirname(__DIR__) . '/tests/Utils');
+    }
+
+    /**
+     * @test
+     * @dataProvider hundredTimes
+     */
+    public static function it_can_validate_os_agnostic_paths(): void
+    {
+        $expected = static::get_expected_path();
+        PathAssertions::assertOsAgnosticPath($expected, static::get_actual_path());
+    }
+
+    /**
+     * @test
+     * @dataProvider hundredTimes
+     */
+    public static function it_can_validate_os_gnostic_paths_fail(): void
+    {
+        $expected = static::get_expected_path();
+        static::assertNotEquals($expected, static::get_actual_path());
+    }
 }

--- a/tests/PathAssertionsTest.php
+++ b/tests/PathAssertionsTest.php
@@ -58,10 +58,15 @@ final class PathAssertionsTest extends TestCase
         PathAssertions::assertExtension($extension, $directory.'/'.$filename.'.'.$extension);
     }
 
-    private static function get_expected_path(): string
+    /**
+     * Detect the OS of the PHP in use and return a path with opposite DIR seperator.
+     *
+     * When given the rand: true parameter it will sometimes provide mixed results.
+     */
+    private static function get_expected_path(bool $rand = false): string
     {
         // Intentionally set the "expected" path to opposite of what should work on the platform.
-        if (PHP_OS_FAMILY !== "Windows") {
+        if (PHP_OS_FAMILY !== "Windows" || ($rand === true && 1 === self::randomInt(0, 4))) {
             return dirname(__DIR__) . '\tests\Utils';
         }
 
@@ -79,7 +84,7 @@ final class PathAssertionsTest extends TestCase
      */
     public static function it_can_validate_os_agnostic_paths(): void
     {
-        $expected = static::get_expected_path();
+        $expected = static::get_expected_path(true);
         PathAssertions::assertOsAgnosticPath($expected, static::get_actual_path());
     }
 

--- a/tests/PathAssertionsTest.php
+++ b/tests/PathAssertionsTest.php
@@ -80,16 +80,7 @@ final class PathAssertionsTest extends TestCase
     public static function it_can_validate_os_agnostic_paths(): void
     {
         $expected = static::os_agnostic_get_expected_path(true);
-        PathAssertions::assertOsAgnosticPath($expected, realpath(dirname(__DIR__) . '/tests/Utils'));
-    }
-
-    /**
-     * @test
-     * @dataProvider hundredTimes
-     */
-    public static function it_can_validate_os_gnostic_paths_fail(): void
-    {
-        $expected = static::os_agnostic_get_expected_path();
         static::assertNotEquals($expected, realpath(dirname(__DIR__) . '/tests/Utils'));
+        PathAssertions::assertOsAgnosticPath($expected, realpath(dirname(__DIR__) . '/tests/Utils'));
     }
 }


### PR DESCRIPTION
# Use Case
Test the expectations of methods that return paths constructed based on PHP constants that will vary by OS platforms. For instance, any PHP constant related to paths will vary from Unix(mac/linux/etc) and Windows due to use of differing directory seperators; even if they are the same equivalent folder.

Packages that seek to have their test suites pass on both Unix and Windows platforms with the same tests will quickly run into test that may pass on linux but fail on windows.

## Example

Per usual, you would provide the expected value first and the actual value second.

```php
\Astrotomic\PhpunitAssertions\PathAssertions::assertOsAgnosticPath(__DIR__ . '/resources/css/main.css', __DIR__ . '\resources\css\main.css');
```

This is a quite literal example where I'm providing literal windows paths for the actual. However consider an application with functions that return paths to resources managed by the app. (laravels resource_path and similar) My Kickflip project would also be a similar project that could use this like:

Current:

```php
        $pageData = ... set to 404 page...;
        self::assertEquals(
            self::agnosticPath('source/404.blade.php'),
            $pageData->source->getRelativePath(),
        );
```

```php
        $pageData = ... set to 404 page...;
        PathAssertions::assertOsAgnosticPath(
            'source/404.blade.php',
            $pageData->source->getRelativePath(),
        );
```

In this case the `getRelativePath` method will derive the relative path based on the full file path. It will just return the relative part based on the "source root folder". So the expected path is predictable however will vary based on OS directory separator - hence the perfect use-case for an assertion like this!

LMK if you have any questions!